### PR TITLE
add tooling schema, active storage, and require username

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :set_locale
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
@@ -21,5 +22,11 @@ class ApplicationController < ActionController::Base
   # This ensures locale persists across navigation
   def default_url_options
     { locale: I18n.locale }
+  end
+
+  # Permit additional Devise parameters such as username to satisfy DB null constraints.
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:username])
   end
 end

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -1,0 +1,8 @@
+class Tool < ApplicationRecord
+  # Owned by a user; attachments hold icon/picture assets via Active Storage.
+  belongs_to :user
+
+  has_one_attached :icon
+  has_one_attached :picture
+end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  # Active Storage avatar to avoid storing URLs directly and allow variants.
+  has_one_attached :avatar
+
+  validates :username, presence: true, uniqueness: true
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,6 +5,7 @@
     <%= f.error_notification %>
 
     <div class="form-inputs">
+      <%= f.input :username, required: true %>
       <%= f.input :email, required: true, autofocus: true %>
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,9 +5,12 @@
     <%= f.error_notification %>
 
     <div class="form-inputs">
-      <%= f.input :email,
+      <%= f.input :username,
                   required: true,
                   autofocus: true,
+                  input_html: { autocomplete: "username" } %>
+      <%= f.input :email,
+                  required: true,
                   input_html: { autocomplete: "email" }%>
       <%= f.input :password,
                   required: true,

--- a/db/migrate/20251209000000_create_tooling_schema.rb
+++ b/db/migrate/20251209000000_create_tooling_schema.rb
@@ -1,0 +1,97 @@
+class CreateToolingSchema < ActiveRecord::Migration[7.1]
+  def change
+    change_table :users, bulk: true do |t|
+      t.string  :username, null: false
+      t.integer :user_type, null: false, default: 0
+      t.integer :user_status, null: false, default: 0
+      t.text    :user_bio
+    end
+
+    add_index :users, :username, unique: true
+
+    create_table :tools do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string  :tool_name, null: false
+      t.text    :tool_description
+      t.string  :tool_url
+      t.text    :author_note
+      t.integer :visibility, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :tools, :tool_name
+
+    create_table :lists do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string  :list_name, null: false
+      t.integer :list_type, null: false, default: 0
+      t.integer :visibility, null: false, default: 0
+
+      t.timestamps
+    end
+
+    create_table :comments do |t|
+      t.references :tool, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text    :comment, null: false
+      t.integer :comment_type, null: false, default: 0
+      t.integer :visibility, null: false, default: 0
+      t.references :parent, foreign_key: { to_table: :comments }
+      t.boolean :solved, null: false, default: false
+
+      t.timestamps
+    end
+
+    create_table :tags do |t|
+      t.string  :tag_name, null: false
+      t.text    :tag_description
+      t.integer :tag_type, null: false, default: 0
+      t.references :parent, foreign_key: { to_table: :tags }
+
+      t.timestamps
+    end
+
+    add_index :tags, :tag_name
+
+    create_table :tool_tags do |t|
+      t.references :tool, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :tool_tags, [:tool_id, :tag_id], unique: true
+
+    create_table :list_tools do |t|
+      t.references :list, null: false, foreign_key: true
+      t.references :tool, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :list_tools, [:list_id, :tool_id], unique: true
+
+    create_table :user_tools do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :tool, null: false, foreign_key: true
+      t.datetime :read_at
+      t.boolean  :upvote, null: false, default: false
+      t.boolean  :favorite, null: false, default: false
+      t.boolean  :subscribe, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :user_tools, [:user_id, :tool_id], unique: true
+
+    create_table :comment_upvotes do |t|
+      t.references :comment, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :comment_upvotes, [:comment_id, :user_id], unique: true
+  end
+end
+

--- a/db/migrate/20251209001000_create_active_storage_tables.rb
+++ b/db/migrate/20251209001000_create_active_storage_tables.rb
@@ -1,0 +1,34 @@
+class CreateActiveStorageTables < ActiveRecord::Migration[7.1]
+  # Standard Active Storage tables (rails active_storage:install), extracted inline
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+      t.datetime :created_at,   null: false
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[blob_id variation_digest], name: "index_active_storage_variant_records_uniqueness", unique: true
+    end
+
+    add_index :active_storage_blobs, :key, unique: true
+    add_index :active_storage_attachments, %i[record_type record_id name blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,130 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_08_082222) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_09_001000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comment_upvotes", force: :cascade do |t|
+    t.bigint "comment_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["comment_id", "user_id"], name: "index_comment_upvotes_on_comment_id_and_user_id", unique: true
+    t.index ["comment_id"], name: "index_comment_upvotes_on_comment_id"
+    t.index ["user_id"], name: "index_comment_upvotes_on_user_id"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.bigint "tool_id", null: false
+    t.bigint "user_id", null: false
+    t.text "comment", null: false
+    t.integer "comment_type", default: 0, null: false
+    t.integer "visibility", default: 0, null: false
+    t.bigint "parent_id"
+    t.boolean "solved", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["parent_id"], name: "index_comments_on_parent_id"
+    t.index ["tool_id"], name: "index_comments_on_tool_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "list_tools", force: :cascade do |t|
+    t.bigint "list_id", null: false
+    t.bigint "tool_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["list_id", "tool_id"], name: "index_list_tools_on_list_id_and_tool_id", unique: true
+    t.index ["list_id"], name: "index_list_tools_on_list_id"
+    t.index ["tool_id"], name: "index_list_tools_on_tool_id"
+  end
+
+  create_table "lists", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "list_name", null: false
+    t.integer "list_type", default: 0, null: false
+    t.integer "visibility", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_lists_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "tag_name", null: false
+    t.text "tag_description"
+    t.integer "tag_type", default: 0, null: false
+    t.bigint "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["parent_id"], name: "index_tags_on_parent_id"
+    t.index ["tag_name"], name: "index_tags_on_tag_name"
+  end
+
+  create_table "tool_tags", force: :cascade do |t|
+    t.bigint "tool_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_tool_tags_on_tag_id"
+    t.index ["tool_id", "tag_id"], name: "index_tool_tags_on_tool_id_and_tag_id", unique: true
+    t.index ["tool_id"], name: "index_tool_tags_on_tool_id"
+  end
+
+  create_table "tools", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "tool_name", null: false
+    t.text "tool_description"
+    t.string "tool_url"
+    t.text "author_note"
+    t.integer "visibility", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tool_name"], name: "index_tools_on_tool_name"
+    t.index ["user_id"], name: "index_tools_on_user_id"
+  end
+
+  create_table "user_tools", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "tool_id", null: false
+    t.datetime "read_at"
+    t.boolean "upvote", default: false, null: false
+    t.boolean "favorite", default: false, null: false
+    t.boolean "subscribe", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tool_id"], name: "index_user_tools_on_tool_id"
+    t.index ["user_id", "tool_id"], name: "index_user_tools_on_user_id_and_tool_id", unique: true
+    t.index ["user_id"], name: "index_user_tools_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -22,8 +143,27 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_08_082222) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username", null: false
+    t.integer "user_type", default: 0, null: false
+    t.integer "user_status", default: 0, null: false
+    t.text "user_bio"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "comment_upvotes", "comments"
+  add_foreign_key "comment_upvotes", "users"
+  add_foreign_key "comments", "comments", column: "parent_id"
+  add_foreign_key "comments", "tools"
+  add_foreign_key "comments", "users"
+  add_foreign_key "list_tools", "lists"
+  add_foreign_key "list_tools", "tools"
+  add_foreign_key "lists", "users"
+  add_foreign_key "tags", "tags", column: "parent_id"
+  add_foreign_key "tool_tags", "tags"
+  add_foreign_key "tool_tags", "tools"
+  add_foreign_key "tools", "users"
+  add_foreign_key "user_tools", "tools"
+  add_foreign_key "user_tools", "users"
 end


### PR DESCRIPTION
### Summary of Changes
- Added tooling schema migration with Active Storage tables for attachments. `db/migrate/20251209000000_create_tooling_schema.rb`, `db/migrate/20251209001000_create_active_storage_tables.rb`
- Enabled Devise to accept `username`, enforced validation, and exposed fields on auth forms. `app/controllers/application_controller.rb`, `app/models/user.rb`, `app/views/devise/registrations/new.html.erb`, `app/views/devise/registrations/edit.html.erb`
- Introduced `Tool` model with Active Storage attachments for icon/picture. `app/models/tool.rb`

### What Was Changed and Why
- **Migrations**: Created core domain tables (tools, lists, comments, tags, joins) and Active Storage tables to support attachments; removed URL columns in favor of attachments. Aligns DB with feature schema.  
  `db/migrate/20251209000000_create_tooling_schema.rb`, `db/migrate/20251209001000_create_active_storage_tables.rb`
- **Devise params**: Permitted `username` on sign-up/account update and validated presence/uniqueness to satisfy NOT NULL/unique constraints and prevent sign-up errors.  
  `app/controllers/application_controller.rb`, `app/models/user.rb`
- **Forms**: Added `username` inputs to registration/edit so users can supply required data.  
  `app/views/devise/registrations/new.html.erb`, `app/views/devise/registrations/edit.html.erb`
- **Tool model**: Added `has_one_attached :icon/:picture` and ownership association to leverage Active Storage instead of URL fields.  
  `app/models/tool.rb`

### How It Works
- Running migrations creates the domain tables and Active Storage infrastructure.  
- Devise now whitelists `username`; validation enforces presence/uniqueness before hitting the DB.  
- Forms collect `username`, preventing PG::NotNullViolation.  
- Tool attachments use Active Storage blobs/variants instead of string URLs.
