### PR TITLE
add CRUD, navbar links, and LLM-ready creation flow

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -1,0 +1,66 @@
+class ToolsController < ApplicationController
+  before_action :set_tool, only: %i[show edit update destroy]
+  before_action :authorize_owner!, only: %i[edit update destroy]
+
+  # GET /tools
+  def index
+    @tools = Tool.includes(:user).order(created_at: :desc)
+  end
+
+  # GET /tools/:id
+  def show
+  end
+
+  # GET /tools/new
+  def new
+    @tool = current_user.tools.new
+  end
+
+  # GET /tools/:id/edit
+  def edit
+  end
+
+  # POST /tools
+  def create
+    @tool = current_user.tools.new(tool_params)
+
+    if @tool.save
+      redirect_to @tool, notice: t("tools.flash.created")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /tools/:id
+  def update
+    if @tool.update(tool_params)
+      redirect_to @tool, notice: t("tools.flash.updated")
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /tools/:id
+  def destroy
+    @tool.destroy
+    redirect_to tools_path, notice: t("tools.flash.destroyed")
+  end
+
+  private
+
+  def set_tool
+    @tool = Tool.find(params[:id])
+  end
+
+  # Ensure only the owner can modify or delete.
+  def authorize_owner!
+    return if @tool.user == current_user
+
+    redirect_to tools_path, alert: t("tools.flash.unauthorized")
+  end
+
+  def tool_params
+    params.require(:tool).permit(:tool_url, :author_note)
+  end
+end
+

--- a/app/views/shared/_navbar_items.html.erb
+++ b/app/views/shared/_navbar_items.html.erb
@@ -5,6 +5,16 @@
       data: { turbo_prefetch: false } %>
 </li>
 <li class="nav-item">
+  <%= link_to "Tools", tools_path,
+      class: "nav-link",
+      data: { turbo_prefetch: false } %>
+</li>
+<li class="nav-item">
+  <%= link_to "New Tool", new_tool_path,
+      class: "nav-link",
+      data: { turbo_prefetch: false } %>
+</li>
+<li class="nav-item">
   <%= link_to "Sign out", destroy_user_session_path,
       class: "nav-link",
       data: { turbo_method: :delete } %>

--- a/app/views/tools/_form.html.erb
+++ b/app/views/tools/_form.html.erb
@@ -1,0 +1,19 @@
+<%= simple_form_for(@tool) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="row g-3">
+    <div class="col-12">
+      <%= f.input :tool_url, label: t("tools.form.tool_url"), required: true %>
+    </div>
+
+    <div class="col-12">
+      <%= f.input :author_note, as: :text, label: t("tools.form.author_note"), input_html: { rows: 3 } %>
+    </div>
+  </div>
+
+  <div class="mt-4 d-flex gap-2">
+    <%= f.button :submit, class: "btn btn-primary" %>
+    <%= link_to t("actions.cancel"), tools_path, class: "btn btn-outline-secondary" %>
+  </div>
+<% end %>
+

--- a/app/views/tools/edit.html.erb
+++ b/app/views/tools/edit.html.erb
@@ -1,0 +1,7 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 m-0"><%= t("tools.edit.title") %></h1>
+  <%= link_to t("actions.back"), tool_path(@tool), class: "btn btn-secondary" %>
+</div>
+
+<%= render "form", tool: @tool %>
+

--- a/app/views/tools/index.html.erb
+++ b/app/views/tools/index.html.erb
@@ -1,0 +1,32 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 m-0"><%= t("tools.index.title") %></h1>
+  <%= link_to t("tools.index.new_tool"), new_tool_path, class: "btn btn-primary" %>
+</div>
+
+<% if @tools.any? %>
+  <div class="row row-cols-1 row-cols-md-2 g-3">
+    <% @tools.each do |tool| %>
+      <div class="col">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body">
+            <div class="d-flex align-items-center justify-content-between">
+              <h2 class="h5 mb-1">
+                <%= link_to tool.tool_name, tool_path(tool), class: "text-decoration-none" %>
+              </h2>
+              <% if tool.icon.attached? %>
+                <%= image_tag tool.icon, class: "rounded", style: "height: 48px; width: 48px; object-fit: cover;" %>
+              <% end %>
+            </div>
+            <p class="text-muted mb-2"><%= truncate(tool.tool_description, length: 140) %></p>
+            <p class="small mb-0 text-secondary">
+              <%= t("tools.index.owner", owner: tool.user.username || tool.user.email) %>
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <div class="alert alert-info"><%= t("tools.index.empty_state") %></div>
+<% end %>
+

--- a/app/views/tools/new.html.erb
+++ b/app/views/tools/new.html.erb
@@ -1,0 +1,7 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 m-0"><%= t("tools.new.title") %></h1>
+  <%= link_to t("actions.back"), tools_path, class: "btn btn-secondary" %>
+</div>
+
+<%= render "form", tool: @tool %>
+

--- a/app/views/tools/show.html.erb
+++ b/app/views/tools/show.html.erb
@@ -1,0 +1,45 @@
+<div class="d-flex justify-content-between align-items-start mb-3">
+  <div>
+    <h1 class="h3 mb-2"><%= @tool.tool_name %></h1>
+    <p class="text-secondary mb-1"><%= t("tools.show.owner", owner: @tool.user.username || @tool.user.email) %></p>
+    <% if @tool.tool_url.present? %>
+      <p class="mb-0">
+        <%= link_to @tool.tool_url, @tool.tool_url, target: "_blank", rel: "noopener noreferrer", class: "text-decoration-none" %>
+      </p>
+    <% end %>
+  </div>
+
+  <div class="d-flex gap-2">
+    <% if @tool.icon.attached? %>
+      <%= image_tag @tool.icon, class: "rounded", style: "height: 64px; width: 64px; object-fit: cover;" %>
+    <% end %>
+  </div>
+</div>
+
+<div class="mb-4">
+  <h2 class="h5"><%= t("tools.show.description") %></h2>
+  <p><%= simple_format(@tool.tool_description) %></p>
+</div>
+
+<div class="mb-4">
+  <h2 class="h5"><%= t("tools.show.author_note") %></h2>
+  <p><%= simple_format(@tool.author_note) %></p>
+</div>
+
+<% if @tool.picture.attached? %>
+  <div class="mb-4">
+    <h2 class="h5"><%= t("tools.show.picture") %></h2>
+    <%= image_tag @tool.picture, class: "img-fluid rounded" %>
+  </div>
+<% end %>
+
+<div class="d-flex gap-2">
+  <% if @tool.user == current_user %>
+    <%= link_to t("actions.edit"), edit_tool_path(@tool), class: "btn btn-outline-primary" %>
+    <%= button_to t("actions.delete"), tool_path(@tool), method: :delete,
+                  data: { turbo_confirm: t("tools.confirmations.destroy") },
+                  class: "btn btn-outline-danger" %>
+  <% end %>
+  <%= link_to t("actions.back"), tools_path, class: "btn btn-secondary" %>
+</div>
+

--- a/config/locales/tools.en.yml
+++ b/config/locales/tools.en.yml
@@ -1,0 +1,41 @@
+en:
+  actions:
+    back: "Back"
+    cancel: "Cancel"
+    edit: "Edit"
+    delete: "Delete"
+  tools:
+    index:
+      title: "Tools"
+      new_tool: "New tool"
+      owner: "by %{owner}"
+      empty_state: "No tools yet. Create the first one!"
+    new:
+      title: "Create tool"
+    edit:
+      title: "Edit tool"
+    show:
+      owner: "Owned by %{owner}"
+      description: "Description"
+      author_note: "Author note"
+      picture: "Picture"
+    form:
+      tool_name: "Name"
+      tool_description: "Description"
+      tool_url: "Link"
+      author_note: "Author note"
+      visibility: "Visibility"
+      icon: "Icon"
+      picture: "Picture"
+    visibility:
+      private: "Private"
+      unlisted: "Unlisted"
+      public: "Public"
+    confirmations:
+      destroy: "Are you sure you want to delete this tool?"
+    flash:
+      created: "Tool created successfully."
+      updated: "Tool updated successfully."
+      destroyed: "Tool deleted."
+      unauthorized: "You are not allowed to modify this tool."
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
     devise_for :users
     root to: "pages#home"
+    resources :tools
     # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
     # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -11,7 +11,7 @@ Server-first Rails 7 + Hotwire app for curating and discussing hacking/engineeri
 ## Core Features
 
 ### Tool Catalog
-- **Status**: Planned
+- **Status**: In Progress
 - **Description**: Users publish tools with descriptions, links, and media. Visibility controls allow private/unlisted/public sharing.
 - **User Stories**:
   - As a user, I want to create a tool entry with description, icon, and link so others can discover it.
@@ -21,6 +21,9 @@ Server-first Rails 7 + Hotwire app for curating and discussing hacking/engineeri
   - Ownership: `Tool` belongs to `User`
   - Visibility/list types modeled as enums on `Tool` and `List`
   - Tagging and list inclusion via join tables
+  - Routes: `resources :tools` (index, show, new, create, edit, update, destroy)
+  - Active Storage attachments for tool `icon` and `picture`
+  - Creation flow: user supplies URL + author note; name/description/picture can be LLM-generated from URL
 - **UI/UX Considerations**:
   - Use Bootstrap grid/cards; responsive at mobile breakpoints
   - Turbo Streams for live updates when tools are added/edited


### PR DESCRIPTION
### Summary of Changes
- Implemented full Tools CRUD with routes, controller, views, i18n, and navbar entries. `config/routes.rb`, `app/controllers/tools_controller.rb`, `app/views/tools/*`, `config/locales/tools.en.yml`, `app/views/shared/_navbar_items.html.erb`
- Added Active Storage-backed Tool model with visibility enum (prefixed), validations, and derived name from URL. `app/models/tool.rb`
- Added Active Storage tables and tooling schema migrations. `db/migrate/20251209000000_create_tooling_schema.rb`, `db/migrate/20251209001000_create_active_storage_tables.rb`
- Simplified tool creation to accept only URL + author note; other fields are LLM-generated later. `app/controllers/tools_controller.rb`, `app/views/tools/_form.html.erb`
- Updated specification to reflect Tool Catalog progress, routes, and LLM-assisted creation flow. `docs/SPECIFICATION.md`

### What Was Changed and Why
- **Tools CRUD & Navigation**: Added `resources :tools`, controller actions (index/show/new/create/edit/update/destroy), Bootstrap-first views, and navbar links so authenticated users can browse and create tools. Ensures server-first flow with Turbo-friendly pages.  
  `1:16:config/routes.rb`  
  `1:67:app/controllers/tools_controller.rb`  
  `1:52:app/views/tools/_form.html.erb`  
  `1:44:app/views/tools/index.html.erb`  
  `1:45:app/views/tools/show.html.erb`  
  `1:7:app/views/shared/_navbar_items.html.erb`
- **Model robustness**: Tool now uses prefixed visibility enum to avoid method collisions, validates URL/name, and auto-derives a name from the URL host to support minimal submission.  
  `1:42:app/models/tool.rb`
- **Creation scope**: Strong params and form restrict input to URL + author note so LLM can generate description/picture/tags later; keeps user flow simple and aligned with requirements.  
  `24:72:app/controllers/tools_controller.rb`  
  `1:52:app/views/tools/_form.html.erb`
- **Migrations**: Created tooling schema (tools, lists, tags, comments, joins, interactions) and Active Storage tables to support attachments.  
  `db/migrate/20251209000000_create_tooling_schema.rb`  
  `db/migrate/20251209001000_create_active_storage_tables.rb`
- **Spec**: Documented Tool Catalog as In Progress, routes, attachments, and LLM-driven creation flow.  
  `13:25:docs/SPECIFICATION.md`

### How It Works
- Signed-in users access Tools via navbar → `/tools`. New tool form accepts URL + author note; controller permits only those fields. Model fills `tool_name` from URL host, validates URL/name, and maintains visibility enum with `_prefix` to avoid `public?` clashes.
- Show page links open URLs in a new tab (`noopener noreferrer`). Attachments remain via Active Storage for future LLM-generated media.
- Published routes enable full CRUD; authorization checks keep edits/deletes to the owner.

