### PR TITLE
Improve UI consistency and fix delete modal/redirect issues

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -108,7 +108,15 @@ class ToolsController < ApplicationController
   # DELETE /tools/:id
   def destroy
     @tool.destroy
-    redirect_to tools_path, notice: t("tools.flash.destroyed")
+    
+    # Force full page redirect by using Turbo-Location header
+    # This ensures Turbo performs a full page load instead of preserving format
+    # Set flash message before redirect
+    flash[:notice] = t("tools.flash.destroyed")
+    # Set Turbo-Location header to force full page navigation
+    response.headers["Turbo-Location"] = root_url
+    # Direct redirect without respond_to to avoid format preservation
+    redirect_to root_path, status: :see_other
   end
 
   # POST /tools/:id/add_tag

--- a/app/views/shared/_confirmation_modal.html.erb
+++ b/app/views/shared/_confirmation_modal.html.erb
@@ -16,7 +16,9 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><%= t("actions.cancel") %></button>
         <% if defined?(form_action) && form_action.present? %>
-          <%= button_to confirm_text || t("actions.confirm"), form_action, method: form_method || :delete, class: "btn #{confirm_class || 'btn-primary'}", form: { id: "#{id}-form", data: { turbo: true } } %>
+          <%# Use turbo: false for delete actions that need full page redirects, turbo: true for Turbo Stream updates %>
+          <% turbo_enabled = defined?(turbo) ? turbo : true %>
+          <%= button_to confirm_text || t("actions.confirm"), form_action, method: form_method || :delete, class: "btn #{confirm_class || 'btn-primary'}", form: { id: "#{id}-form", data: { turbo: turbo_enabled } } %>
         <% else %>
           <button type="button" class="btn <%= confirm_class || 'btn-primary' %>" data-action="click->confirmation-modal#confirm"><%= confirm_text || t("actions.confirm") %></button>
         <% end %>

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -56,6 +56,87 @@
       </div>
     </div>
 
+    <%# Show additional fields when editing (especially for admins) %>
+    <% if @submission.persisted? %>
+      <div class="col-12">
+        <label class="form-label fw-semibold mb-2">
+          <%= t("submissions.form.submission_name") %>
+          <span class="text-muted small fw-normal">(<%= t("submissions.form.optional") %>)</span>
+        </label>
+        <%= f.input :submission_name,
+            label: false,
+            input_html: { 
+              class: "form-control",
+              placeholder: t("submissions.form.submission_name_hint")
+            },
+            hint: t("submissions.form.submission_name_hint") %>
+      </div>
+
+      <div class="col-12">
+        <label class="form-label fw-semibold mb-2">
+          <%= t("submissions.form.submission_description") %>
+          <span class="text-muted small fw-normal">(<%= t("submissions.form.optional") %>)</span>
+        </label>
+        <%= f.input :submission_description,
+            as: :text,
+            label: false,
+            input_html: { 
+              class: "form-control",
+              rows: 5,
+              placeholder: t("submissions.form.submission_description_hint")
+            },
+            hint: t("submissions.form.submission_description_hint") %>
+      </div>
+
+      <%# Tool selection (for admins) %>
+      <% if admin_user? && defined?(@available_tools) && @available_tools.present? %>
+        <div class="col-12">
+          <label class="form-label fw-semibold mb-2">
+            <%= t("submissions.form.tools") %>
+            <span class="text-muted small fw-normal">(<%= t("submissions.form.optional") %>)</span>
+          </label>
+          <div class="border rounded p-3" style="min-height: 150px; max-height: 300px; overflow-y: auto; background-color: #f8f9fa;">
+            <% @available_tools.each do |tool| %>
+              <div class="form-check">
+                <%= check_box_tag "submission[tool_ids][]", tool.id, @submission.tools.include?(tool), 
+                    id: "submission_tool_ids_#{tool.id}",
+                    class: "form-check-input" %>
+                <%= label_tag "submission_tool_ids_#{tool.id}", tool.tool_name, class: "form-check-label" %>
+              </div>
+            <% end %>
+          </div>
+          <small class="form-text text-muted"><%= t("submissions.form.tools_hint") %></small>
+        </div>
+      <% end %>
+
+      <%# Submission type and status (for admins only) %>
+      <% if admin_user? %>
+        <div class="col-12 col-md-6">
+          <label class="form-label fw-semibold mb-2">
+            <%= t("submissions.form.submission_type") %>
+          </label>
+          <%= f.input :submission_type,
+              as: :select,
+              collection: Submission.submission_types.keys.map { |type| [t("submissions.types.#{type}"), type] },
+              label: false,
+              input_html: { class: "form-select" },
+              hint: t("submissions.form.submission_type_hint") %>
+        </div>
+
+        <div class="col-12 col-md-6">
+          <label class="form-label fw-semibold mb-2">
+            <%= t("submissions.form.status") %>
+          </label>
+          <%= f.input :status,
+              as: :select,
+              collection: Submission.statuses.keys.map { |status| [t("submissions.statuses.#{status}"), status] },
+              label: false,
+              input_html: { class: "form-select" },
+              hint: t("submissions.form.status_hint") %>
+        </div>
+      <% end %>
+    <% end %>
+
     <div class="col-12">
       <label class="form-label fw-semibold mb-2">
         <%= t("submissions.form.author_note") %>
@@ -77,12 +158,12 @@
   <div class="mt-4 pt-3 border-top d-flex gap-2">
     <%= f.button :submit, 
         class: "btn btn-primary btn-lg",
-        disabled: true,
+        disabled: @submission.new_record?,
         data: { submission_form_target: "submitButton" } do %>
       <i class="bi bi-send me-2"></i>
-      <%= t("submissions.form.submit") %>
+      <%= @submission.new_record? ? t("submissions.form.submit") : t("actions.update") %>
     <% end %>
-    <%= link_to t("actions.cancel"), submissions_path, class: "btn btn-outline-secondary btn-lg" %>
+    <%= link_to t("actions.cancel"), @submission.persisted? ? submission_path(@submission) : submissions_path, class: "btn btn-outline-secondary btn-lg" %>
   </div>
 <% end %>
 

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -24,14 +24,6 @@
                   <% if @submission.user == current_user || admin_user? %>
                     <div class="position-absolute bottom-0 end-0 mb-3 me-3 d-flex gap-2" style="z-index: 10;">
                       <%= link_to t("actions.edit"), edit_submission_path(@submission), class: "btn btn-outline-primary btn-sm" %>
-                      <%= render "shared/confirmation_modal",
-                          id: "delete-submission-modal",
-                          title: t("submissions.confirmations.destroy_title"),
-                          message: t("submissions.confirmations.destroy_message"),
-                          confirm_text: t("actions.delete"),
-                          confirm_class: "btn-outline-danger",
-                          form_action: submission_path(@submission),
-                          form_method: :delete %>
                       <button type="button" class="btn btn-outline-danger btn-sm" data-bs-toggle="modal" data-bs-target="#delete-submission-modal">
                         <%= t("actions.delete") %>
                       </button>
@@ -403,4 +395,17 @@
     <%= render "shared/side_banner", position: "right", used_images: used_images %>
   </div>
 </div>
+
+<%# Confirmation Modal for Submission Deletion - rendered outside positioned containers to avoid z-index issues %>
+<% if @submission.user == current_user || admin_user? %>
+  <%= render "shared/confirmation_modal",
+      id: "delete-submission-modal",
+      title: t("submissions.confirmations.destroy_title"),
+      message: t("submissions.confirmations.destroy_message"),
+      confirm_text: t("actions.delete"),
+      confirm_class: "btn-outline-danger",
+      form_action: submission_path(@submission),
+      form_method: :delete,
+      turbo: false %>
+<% end %>
 

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -4,7 +4,9 @@
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="h3 mb-0"><%= t("tags.index.title") %></h1>
     <% if admin_user? %>
-      <%= link_to t("tags.actions.new"), new_tag_path, class: "btn btn-primary" %>
+      <%= link_to new_tag_path, class: "btn btn-primary btn-lg square-plus-btn", aria: { label: t("tags.actions.new") } do %>
+        <i class="bi bi-plus-lg"></i>
+      <% end %>
     <% end %>
   </div>
   <% if @tags_by_type.any? %>
@@ -45,7 +47,9 @@
     <div class="alert alert-light border">
       <p class="mb-0"><%= t("tags.index.empty") %></p>
       <% if admin_user? %>
-        <%= link_to t("tags.actions.new"), new_tag_path, class: "btn btn-primary mt-2" %>
+        <%= link_to new_tag_path, class: "btn btn-primary btn-lg square-plus-btn mt-2", aria: { label: t("tags.actions.new") } do %>
+          <i class="bi bi-plus-lg"></i>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/tools/show.html.erb
+++ b/app/views/tools/show.html.erb
@@ -18,14 +18,6 @@
                   <% if admin_user? %>
                     <div class="position-absolute bottom-0 end-0 mb-3 me-3 d-flex gap-2" style="z-index: 10;">
                       <%= link_to t("actions.edit"), edit_tool_path(@tool), class: "btn btn-outline-primary btn-sm" %>
-                      <%= render "shared/confirmation_modal",
-                          id: "delete-tool-modal",
-                          title: t("tools.confirmations.destroy_title"),
-                          message: t("tools.confirmations.destroy_message"),
-                          confirm_text: t("actions.delete"),
-                          confirm_class: "btn-outline-danger",
-                          form_action: tool_path(@tool),
-                          form_method: :delete %>
                       <button type="button" class="btn btn-outline-danger btn-sm" data-bs-toggle="modal" data-bs-target="#delete-tool-modal">
                         <%= t("actions.delete") %>
                       </button>
@@ -392,3 +384,16 @@
     <%= render "shared/side_banner", position: "right", used_images: used_images %>
   </div>
 </div>
+
+<%# Confirmation Modal for Tool Deletion - rendered outside positioned containers to avoid z-index issues %>
+<% if admin_user? %>
+  <%= render "shared/confirmation_modal",
+      id: "delete-tool-modal",
+      title: t("tools.confirmations.destroy_title"),
+      message: t("tools.confirmations.destroy_message"),
+      confirm_text: t("actions.delete"),
+      confirm_class: "btn-outline-danger",
+      form_action: tool_path(@tool),
+      form_method: :delete,
+      turbo: false %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -448,6 +448,7 @@ en:
   # Account Settings (custom, independent from Devise)
   account_settings:
     title: "Account Settings"
+    subtitle: "Manage your profile information and security settings."
     back: "Back to Profile"
     avatar:
       title: "Profile Picture"

--- a/config/locales/submissions.en.yml
+++ b/config/locales/submissions.en.yml
@@ -82,6 +82,10 @@ en:
       tool: "Related Tool"
       tool_hint: "Optional - select a tool this submission is about"
       tool_prompt: "Select a tool (optional)"
+      submission_type: "Submission Type"
+      submission_type_hint: "Type of content (article, guide, documentation, etc.)"
+      status: "Status"
+      status_hint: "Processing status of the submission"
     confirmations:
       destroy_title: "Delete Submission"
       destroy_message: "Are you sure you want to delete this submission? This action cannot be undone."


### PR DESCRIPTION
- Add meaningful subtitle to account settings page
- Change 'New tag' button to plus icon button matching navbar style
- Fix submission delete modal z-index issues by moving outside positioned containers
- Fix submission delete redirect to properly navigate to home page with Turbo-Location header
- Disable Turbo on delete forms to allow proper HTML redirects
- Apply same improvements to tool delete functionality
- Add all editable fields to submission edit form for admins:
  - submission_name, submission_description fields
  - Tool selection checkboxes (admin only)
  - submission_type and status dropdowns (admin only)
- Update controllers to permit admin-only fields (submission_type, status)
- Enable submit button when editing (was disabled for new submissions only)
- Update cancel button to return to submission show page when editing